### PR TITLE
Add LoT Alpha Pack Token (cw20)

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -602,6 +602,14 @@ module.exports = {
       icon: "https://thorstarter.org/static/img/src/favicon.png",
       decimals: 6
     },
+    terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784: {
+      protocol: "LoT",
+      symbol: "aLOT",
+      name: "Alpha Pack Token",
+      token: "terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784",
+      icon: "https://ipfs.playlot.io/icon/profile-logo.png",
+      decimals: 0
+    },
   },
   testnet: {
     terra1v000amr8a59r88p33ec2kk9xqe047g7zzqqaf4: {
@@ -989,14 +997,6 @@ module.exports = {
       token: "terra1skhz70xtsjvmx29zp5tdrqu84amc7nzrlvw9st",
       icon: "https://raw.githubusercontent.com/orbitalwolf/noks/main/logo.png",
       decimals: 6
-    },
-    terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784: {
-      protocol: "LoT",
-      symbol: "aLOT",
-      name: "Alpha Pack Token",
-      token: "terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784",
-      icon: "https://ipfs.playlot.io/icon/profile-logo.png",
-      decimals: 0
     },
   }
 }

--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -981,6 +981,14 @@ module.exports = {
       token: "terra1skhz70xtsjvmx29zp5tdrqu84amc7nzrlvw9st",
       icon: "https://raw.githubusercontent.com/orbitalwolf/noks/main/logo.png",
       decimals: 6
-    },    
+    },
+    terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784: {
+      protocol: "LoT",
+      symbol: "aLOT",
+      name: "Alpha Pack Token",
+      token: "terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784",
+      icon: "https://ipfs.playlot.io/icon/profile-logo.png",
+      decimals: 0
+    },
   }
 }


### PR DESCRIPTION
The team Legends of Terra has opened the public sale of the alpha pack token (cw20). We want the token to be listed as a Terra asset. Thanks!

[https://playlot.io](https://playlot.io)