### PR TITLE
Added Sdollar token

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -1030,5 +1030,13 @@ module.exports = {
       icon: "https://orne.io/img/token_icon.png",
       decimals: 6
     },
+      terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq: {
+      protocol: "Space Dollar Society",
+      symbol: "SDOLLAR",
+      name: "Space Dollar",
+      token: "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
+      icon: "https://sdollars.wpengine.com/wp-content/uploads/2021/10/spacedollars512x512.png",
+      decimals: 2
+    },
   }
 }


### PR DESCRIPTION
Space Dollar token is used to gain access to Space Dollar Society, it's also used to farm tickets that are redeemable for NFTs