### PR TITLE
Add Wormhole bETH token to mainnet

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -461,6 +461,14 @@ module.exports = {
       icon: "https://static.lido.fi/LDO/LDO.png",
       decimals: 8
     },
+    terra1u5szg038ur9kzuular3cae8hq6q5rk5u27tuvz: {
+      protocol: "Wormhole",
+      symbol: "whbETH",
+      name: "Lido Bonded ETH (Wormhole)",
+      token: "terra1u5szg038ur9kzuular3cae8hq6q5rk5u27tuvz",
+      icon: "https://static.lido.fi/bETH_Wormhole/bETH_Wormhole.svg",
+      decimals: 8
+    },
     terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc: {
       protocol: "Lido",
       symbol: "stLuna",

--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -1049,7 +1049,7 @@ module.exports = {
     },
     terra1d74gfj8gs6rskcuu80x3deus7gut77udhdajv7: {
       protocol: "Wormhole",
-      symbol: "webETH",
+      symbol: "whbETH",
       name: "Lido Bonded ETH (Wormhole)",
       token: "terra1d74gfj8gs6rskcuu80x3deus7gut77udhdajv7",
       icon: "https://static.lido.fi/bETH_Wormhole/bETH_Wormhole.svg",


### PR DESCRIPTION
* Adds Wormhole version of the bETH token to mainnet.
* Fixes the name of the token on testnet to match the mainnet one.