### PR TITLE
Use conventional Wormhole bETH token name

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -463,7 +463,7 @@ module.exports = {
     },
     terra1u5szg038ur9kzuular3cae8hq6q5rk5u27tuvz: {
       protocol: "Wormhole",
-      symbol: "whbETH",
+      symbol: "webETH",
       name: "Lido Bonded ETH (Wormhole)",
       token: "terra1u5szg038ur9kzuular3cae8hq6q5rk5u27tuvz",
       icon: "https://static.lido.fi/bETH_Wormhole/bETH_Wormhole.svg",
@@ -1057,7 +1057,7 @@ module.exports = {
     },
     terra1d74gfj8gs6rskcuu80x3deus7gut77udhdajv7: {
       protocol: "Wormhole",
-      symbol: "whbETH",
+      symbol: "webETH",
       name: "Lido Bonded ETH (Wormhole)",
       token: "terra1d74gfj8gs6rskcuu80x3deus7gut77udhdajv7",
       icon: "https://static.lido.fi/bETH_Wormhole/bETH_Wormhole.svg",


### PR DESCRIPTION
Change the Wormhole bETH token name to follow the Wormhole token naming convention used in Terra (the `we` prefix designates the Ethereum origin of the token).