### PR TITLE
Change whLDO to weLDO

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -455,7 +455,7 @@ module.exports = {
     },
     terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z: {
       protocol: "Wormhole",
-      symbol: "whLDO",
+      symbol: "weLDO",
       name: "Lido DAO Token (Wormhole)",
       token: "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
       icon: "https://static.lido.fi/LDO/LDO.png",


### PR DESCRIPTION
Changed the whLDO symbol to weLDO so it would be compatible with calling convention for Ethereum assets bridged with Wormhole