### PR TITLE
feat: migrate Orne to astroport

### DIFF
--- a/cw20/contracts.js
+++ b/cw20/contracts.js
@@ -1015,7 +1015,7 @@ module.exports = {
       name: "Orca aUST Vault",
       icon: "https://assets.kujira.app/kuji.png",
     },
-    terra1mz0p4wzz5tmethu7rca2jjrw077hv2ypj7h06z: {
+    terra13yftwgefkggq3u627gphq98s6ufwh9u85h5kmg: {
       protocol: "Orne",
       name: "UST-ORNE Pair",
       icon: "https://orne.io/img/token_icon.png",
@@ -2106,7 +2106,7 @@ module.exports = {
       name: "TerraFloki UST-TFLOKI LP New World Staking",
       icon: "https://terrafloki.io/ticket2_logo.png"
     },
-    terra1cc5p6u7fm3eh9m2h0jjjay4hlluw5e32mtstjd: {
+    terra1eqzmr4gcx7vtwgcxvg86ccsaly8xqzwu0wu47u: {
       protocol: "Orne",
       name: "UST-ORNE Pair",
       icon: "https://orne.io/img/token_icon.png",

--- a/cw20/pairs.dex.js
+++ b/cw20/pairs.dex.js
@@ -235,8 +235,8 @@ module.exports = {
       type: "xyk",
       assets: ["terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup", "uluna"],
     },
-    terra1mz0p4wzz5tmethu7rca2jjrw077hv2ypj7h06z: {
-      dex: "terraswap",
+    terra13yftwgefkggq3u627gphq98s6ufwh9u85h5kmg: {
+      dex: "astroport",
       type: "xyk",
       assets: ["uusd", "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf"],
     },
@@ -527,8 +527,8 @@ module.exports = {
       type: "xyk",
       assets: ["uusd", "terra1azu2frwn9a4l6gl5r39d0cuccs4h7xlu9gkmtd"],
     },
-    terra1cc5p6u7fm3eh9m2h0jjjay4hlluw5e32mtstjd: {
-      dex: "terraswap",
+    terra1eqzmr4gcx7vtwgcxvg86ccsaly8xqzwu0wu47u: {
+      dex: "astroport",
       type: "xyk",
       assets: ["uusd", "terra182zp52a95r3qg6lt0njxr7l0ujkfwan5h7t3l6"],
     },

--- a/cw20/pairs.js
+++ b/cw20/pairs.js
@@ -188,7 +188,7 @@ module.exports = {
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uluna"
     ],
-    terra1mz0p4wzz5tmethu7rca2jjrw077hv2ypj7h06z: [
+    terra13yftwgefkggq3u627gphq98s6ufwh9u85h5kmg: [
       "uusd",
       "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf"
     ],
@@ -398,7 +398,7 @@ module.exports = {
       "uluna",
       "terra1xpz9mlf04c0q3xy9fzgjvmdgwk5e8kageja3mu"
     ],
-    terra1cc5p6u7fm3eh9m2h0jjjay4hlluw5e32mtstjd: [
+    terra1eqzmr4gcx7vtwgcxvg86ccsaly8xqzwu0wu47u: [
       "uusd",
       "terra182zp52a95r3qg6lt0njxr7l0ujkfwan5h7t3l6"
     ],


### PR DESCRIPTION
Hey! 👋🏻 

We have migrated $ORNE to Astroport.
This PR removes the TerraSwap pair and registration to only use the Astroport one.