### PR TITLE
feat(vUST-WHALE): Add vUST-WHALE pair contract to pairs.js

### DIFF
--- a/cw20/pairs.js
+++ b/cw20/pairs.js
@@ -244,6 +244,10 @@ module.exports = {
       "uusd",
       "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx"
     ],
+    terra12arl49w7t4xpq7krtv43t3dg6g8kn2xxyaav56: [
+      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
+      "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
+    ],
   },
   testnet: {
     terra1rfzwcdhhu502xws6r5pxw4hx8c6vms772d6vyu: [


### PR DESCRIPTION
This is a pair between WHALE:terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz and vUST:terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg

To enable swapping between the two in Terraswap