### PR TITLE
Add testnet Wormhole bSOL

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -1388,5 +1388,13 @@ module.exports = {
       icon: "https://benqi.fi/images/assets/savax.svg",
       decimals: 8,
     },
+    terra1spt8mjrg5w8er4na206x24gyrtvr278q78vpwa: {
+      protocol: "Wormhole",
+      symbol: "wbSOL",
+      name: "Lido Bonded SOL (test) (Wormhole)",
+      token: "terra1spt8mjrg5w8er4na206x24gyrtvr278q78vpwa",
+      icon: "https://raw.githubusercontent.com/ChorusOne/token-list/main/assets/mainnet/EbMg3VYAE9Krhndw7FuogpHNcEPkXVhtXr7mGisdeaur/logo.svg",
+      decimals: 8,
+    },
   }
 }


### PR DESCRIPTION
This adds token metadata for Wormhole-wrapped test bSOL.

This is part of testing the Anchor integration of Lido for Solana, which will allow users of Anchor to use staked SOL as collateral. See also https://github.com/ChorusOne/solido/milestone/4.

This is one particular test for bSOL, we might redeploy the setup later and change the addresses, but for now we want to be able to use this deployment for testing.

Solana devnet token address: https://explorer.solana.com/address/BSo147oW1Nd2AmVKHCgEz9hGAQ9zZLqZWTAXp3p3gxPQ?cluster=devnet
Registration transaction: https://finder.terra.money/bombay-12/tx/615F21A519D5BF38D35789DF4D3F8CE1A67739B0D7738A03F50A6CA1F8FA0D79
Terra testnet token address: https://finder.terra.money/testnet/address/terra1spt8mjrg5w8er4na206x24gyrtvr278q78vpwa

The token on Solana has 9 decimals, but Wormhole creates a token with 8 decimals on Terra.