### PR TITLE
Fix up LINK token definition

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -945,6 +945,7 @@ module.exports = {
       decimals: 8,
     },
     terra1su6g4t4vwx7y0uh3ksancyaurj4l6w9pfs40qt: {
+      protocol: "Chainlink",
       symbol: "LINK",
       name: "ChainLink Token",
       token: "terra1su6g4t4vwx7y0uh3ksancyaurj4l6w9pfs40qt",


### PR DESCRIPTION
It's showing up as "undefined LINK Token" in the finder, so I guess the "protocol" property
is needed and "name" is ignored?