### PR TITLE
feat: add bSOL anchor token to testnet

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -1483,6 +1483,14 @@ module.exports = {
       icon: "https://benqi.fi/images/assets/savax.svg",
       decimals: 8,
     },
+    terra17ewm2qjljcvfpmsnje68fnf7tnxecw4prs84sx: {
+      protocol: "Anchor",
+      symbol: "bSOL",
+      name: "Bonded SOL",
+      token: "terra17ewm2qjljcvfpmsnje68fnf7tnxecw4prs84sx",
+      icon: "https://raw.githubusercontent.com/ChorusOne/token-list/main/assets/mainnet/EbMg3VYAE9Krhndw7FuogpHNcEPkXVhtXr7mGisdeaur/logo.svg",
+      decimals: 6,
+    },
     terra1spt8mjrg5w8er4na206x24gyrtvr278q78vpwa: {
       protocol: "Wormhole",
       symbol: "wbSOL",


### PR DESCRIPTION
## This PR...

Adds bSOL Anchor token to testnet.

### Token Info: 

- address: https://finder.terra.money/testnet/address/terra17ewm2qjljcvfpmsnje68fnf7tnxecw4prs84sx
- decimals: 6

