### PR TITLE
added more entries to blacklist

### DIFF
--- a/blacklist.json
+++ b/blacklist.json
@@ -494,5 +494,8 @@
   "app-astroport-fl.digital",
   "stakeanchor.net",
   "terra-station.app",
-  "stationterra-connect.com"
+  "stationterra-connect.com",
+  "terramoneyservice.com",
+  "terra-ecosystem.com",
+  "terra-ecosystem.xyz"
 ]


### PR DESCRIPTION
they all host scam websites at "/en" route, so full urls would be 
* terramoneyservice.com/en
* terra-ecosystem.com/en
* terra-ecosystem.xyz/en