### PR TITLE
Update token.js to add xASTRO token.

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -649,6 +649,13 @@ module.exports = {
       token: "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       icon: "https://astroport.fi/astro_logo.png",
     },
+    terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7: {
+      protocol: "Astroport",
+      symbol: "xASTRO",
+      name: "xASTRO Token",
+      token: "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
+      icon: "https://app.astroport.fi/tokens/xAstro.png",
+    },
     terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq: {
       protocol: "Angel Protocol",
       symbol: "HALO",


### PR DESCRIPTION
Adding xASTRO token to the mainnet list. Source of Token Address - https://astroport.medium.com/astroport-upgrade-unleashed-governance-staking-and-fee-share-8d17e4adb97c.