### PR TITLE
Add xASTRO token and add decimal parameter to ASTRO

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -648,6 +648,15 @@ module.exports = {
       name: "Astroport Token",
       token: "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       icon: "https://astroport.fi/astro_logo.png",
+      decimals: 6,
+    },
+    terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7: {
+      protocol: "Astroport",
+      symbol: "xASTRO",
+      name: "Staked Astroport Token",
+      token: "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
+      icon: "https://app.astroport.fi/tokens/xAstro.png",
+      decimals: 6,
     },
     terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq: {
       protocol: "Angel Protocol",


### PR DESCRIPTION
Adding xASTRO token to the mainnet list and also adding the decimal parameter to ASTRO token. Source of Token Address - https://astroport.medium.com/astroport-upgrade-unleashed-governance-staking-and-fee-share-8d17e4adb97c.