### PR TITLE
Add mainnet Wormhole-wrapped bSOL

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -539,6 +539,14 @@ module.exports = {
       icon: "https://static.lido.fi/stSOL/stSOL.png",
       decimals: 8
     },
+    terra1c3xd5s2j3ejx2d94tvcjfkrdeu6rmz48ghzznj: {
+      protocol: "Wormhole",
+      symbol: "wsbSOL",
+      name: "Lido bonded SOL (Portal)",
+      token: "terra1c3xd5s2j3ejx2d94tvcjfkrdeu6rmz48ghzznj",
+      icon: "https://raw.githubusercontent.com/ChorusOne/token-list/main/assets/mainnet/EbMg3VYAE9Krhndw7FuogpHNcEPkXVhtXr7mGisdeaur/logo.svg",
+      decimals: 8
+    },
     terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z: {
       protocol: "Wormhole",
       symbol: "weLDO",


### PR DESCRIPTION
`terra1c3xd5s2j3ejx2d94tvcjfkrdeu6rmz48ghzznj` is the Wormhole-wrapped version of bSOL on Solana (https://explorer.solana.com/address/EbMg3VYAE9Krhndw7FuogpHNcEPkXVhtXr7mGisdeaur/metadata).

I see the names are being changed in #393 from “(Wormhole)” to “(Portal)”, so I added it with “(Portal)” suffix already. I hope it doesn’t cause any more confusion.