### PR TITLE
Replace PAXG icon url with link to actual image

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -991,7 +991,7 @@ module.exports = {
       symbol: "PAXG",
       name: "Paxos Gold (Portal)",
       token: "terra1uux6gwd6pzr0gfzrru5kne55cxex9d0700c72r",
-      icon: "https://github.com/paxosglobal/paxos-gold-contract/blob/master/assets/Pax-Gold-Logo-FINAL-color.png",
+      icon: "https://github.com/paxosglobal/paxos-gold-contract/blob/master/assets/Pax-Gold-Logo-FINAL-color.png?raw=true",
       decimals: 8,
     },
     terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl: {


### PR DESCRIPTION
it currently points to the github file detail page instead, unlike every other icon URL in tokens.js