### PR TITLE
Update Leap Wallet logo URL

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -26,7 +26,7 @@
     {
       "name": "Leap Wallet",
       "identifier": "leap-wallet",
-      "icon": "https://bit.ly/39CMJLF",
+      "icon": "https://bit.ly/L3APLOGO",
       "urls": [
         {
           "browser": "chrome",

--- a/extensions.json
+++ b/extensions.json
@@ -26,7 +26,7 @@
     {
       "name": "Leap Wallet",
       "identifier": "leap-wallet",
-      "icon": "https://leapwallet.io/icon.png",
+      "icon": "https://bit.ly/39CMJLF",
       "urls": [
         {
           "browser": "chrome",


### PR DESCRIPTION
Sorry about this. They deprecated the URL I just PR'd last time.