### PR TITLE
Fix pairs.dex.js

### DIFF
--- a/cw20/pairs.dex.js
+++ b/cw20/pairs.dex.js
@@ -525,8 +525,7 @@ module.exports = {
       type: "xyk",
       assets: ["uusd", "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp"],
     },
-  },
-      terra1esm0pztzdq6hqgtj72w9dsnlfwtm343c7axvxu: {
+    terra1esm0pztzdq6hqgtj72w9dsnlfwtm343c7axvxu: {
       dex: "astroport",
       type: "xyk",
       assets: ["uluna", "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp"],


### PR DESCRIPTION
Fix pairs.dex.js

```
  testnet: {},
         ^

SyntaxError: Unexpected token ':'
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1049:15)
    at Module._compile (node:internal/modules/cjs/loader:1084:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1174:10)
    at Module.load (node:internal/modules/cjs/loader:998:32)
    at Module._load (node:internal/modules/cjs/loader:839:12)
    at Module.require (node:internal/modules/cjs/loader:1022:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at /Users/thomaswos/git/terra/assets/index.js:15:20
    at Array.forEach (<anonymous>)


```