### PR TITLE
Removed last comma from JSON

### DIFF
--- a/blacklist.json
+++ b/blacklist.json
@@ -536,5 +536,5 @@
   "aterra2.at",
   "cterra2.at",
   "vterra3.at",
-  "iatom2.at",
+  "iatom2.at"
 ]


### PR DESCRIPTION
The last comma in the JSON caused the file to break and not work when the browser makes the request.

https://assets.terra.money/blacklist.json